### PR TITLE
fix(history): batch getHistory requests instead of one RPC per message

### DIFF
--- a/cmd/tg/history.go
+++ b/cmd/tg/history.go
@@ -59,7 +59,14 @@ func (h historyResult) MarshalText(w io.Writer) error {
 // listHistory reads up to limit recent messages from peer (newest-first from the
 // API), returning them oldest-first.
 func listHistory(ctx context.Context, api *tg.Client, peer tg.InputPeerClass, limit int) (historyResult, error) {
-	iter := query.Messages(api).GetHistory(peer).Iter()
+	// Fetch in large batches to minimize round trips. The iterator's default
+	// batch size is 1, so it issues one messages.getHistory RPC per message,
+	// which makes larger --limit values extremely slow. Telegram does not
+	// reject a per-request limit above 100 but silently returns fewer/incorrect
+	// results, so cap at 100. Clamp to at least 1: a non-positive batch size
+	// would panic the iterator (it preallocates a slice with that capacity).
+	batch := max(1, min(limit, 100))
+	iter := query.Messages(api).GetHistory(peer).BatchSize(batch).Iter()
 
 	var res historyResult
 	for iter.Next(ctx) {

--- a/cmd/tg/history_test.go
+++ b/cmd/tg/history_test.go
@@ -64,3 +64,41 @@ func TestListHistoryLimit(t *testing.T) {
 		t.Fatalf("limit not respected: got %d", len(res.Messages))
 	}
 }
+
+// TestListHistoryBatchSize asserts the per-request limit is batched (capped at
+// 100) instead of the iterator default of 1, and never goes below 1 (a
+// non-positive batch size panics the iterator).
+func TestListHistoryBatchSize(t *testing.T) {
+	for _, tt := range []struct {
+		limit     int
+		wantBatch int
+	}{
+		{limit: 5, wantBatch: 5},
+		{limit: 100, wantBatch: 100},
+		{limit: 350, wantBatch: 100},
+		{limit: 0, wantBatch: 1},
+		{limit: -1, wantBatch: 1},
+	} {
+		var gotBatch int
+		api := newFuncAPI(t, func(req bin.Encoder) (bin.Encoder, error) {
+			r, ok := req.(*tg.MessagesGetHistoryRequest)
+			if !ok {
+				return nil, errors.Errorf("unexpected request %T", req)
+			}
+			gotBatch = r.Limit
+			return &tg.MessagesMessages{
+				Messages: []tg.MessageClass{
+					&tg.Message{ID: 1, PeerID: &tg.PeerUser{UserID: 5}, Date: 1},
+				},
+				Users: []tg.UserClass{&tg.User{ID: 5}},
+			}, nil
+		})
+
+		if _, err := listHistory(context.Background(), api, &tg.InputPeerSelf{}, tt.limit); err != nil {
+			t.Fatalf("limit %d: %v", tt.limit, err)
+		}
+		if gotBatch != tt.wantBatch {
+			t.Errorf("limit %d: request limit = %d, want %d", tt.limit, gotBatch, tt.wantBatch)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`tg history --limit N` is extremely slow for anything beyond a handful of messages — fetching ~350 messages did not finish in 7 minutes.

The cause is in `listHistory`: the gotd `messages` iterator is created with `query.Messages(api).GetHistory(peer).Iter()`, leaving the builder's **default batch size of 1**. The iterator therefore issues one `messages.getHistory` RPC *per message* (hundreds of round trips for a few hundred messages).

## Fix

Set `BatchSize(max(1, min(limit, 100)))` on the builder:

- **Cap at 100** — Telegram does not reject a per-request limit above 100, but silently returns fewer/incorrect results (see gotd's own `BatchSize` doc), so 100 is the safe maximum.
- **Clamp to ≥ 1** — a non-positive batch size panics the iterator (`NewIterator` preallocates a slice with that capacity), so a negative `--limit` would otherwise crash the process.

Fetching 350 messages now takes ~3.5s (≈4 RPCs) instead of timing out.

## Tests

Adds `TestListHistoryBatchSize`, asserting the per-request limit sent is `5/100/100` for `--limit 5/100/350` and clamps to `1` for `--limit 0/-1` (no panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)