### PR TITLE
fix(chats,drafts): batch getDialogs requests instead of one RPC per dialog

### DIFF
--- a/cmd/tg/chats.go
+++ b/cmd/tg/chats.go
@@ -74,7 +74,14 @@ func listChats(ctx context.Context, api *tg.Client, m *peerManager, limit int, a
 		folder = 1
 	}
 
-	iter := query.GetDialogs(api).FolderID(folder).Iter()
+	// Fetch in large batches to minimize round trips. The dialogs iterator's
+	// default batch size is 1, so it issues one messages.getDialogs RPC per
+	// dialog, which makes listing slow. Telegram does not reject a per-request
+	// limit above 100 but silently returns fewer/incorrect results, so cap at
+	// 100. Clamp to at least 1: a non-positive batch size would panic the
+	// iterator (it preallocates a slice with that capacity).
+	batch := max(1, min(limit, 100))
+	iter := query.GetDialogs(api).FolderID(folder).BatchSize(batch).Iter()
 	now := time.Now().Unix()
 
 	var (

--- a/cmd/tg/chats_test.go
+++ b/cmd/tg/chats_test.go
@@ -75,3 +75,40 @@ func TestListChatsLimit(t *testing.T) {
 		t.Fatalf("limit not respected: got %d", len(list.Chats))
 	}
 }
+
+// TestListChatsBatchSize asserts the per-request limit is batched (capped at
+// 100) instead of the iterator default of 1, and never goes below 1 (a
+// non-positive batch size panics the iterator).
+func TestListChatsBatchSize(t *testing.T) {
+	for _, tt := range []struct {
+		limit     int
+		wantBatch int
+	}{
+		{limit: 5, wantBatch: 5},
+		{limit: 100, wantBatch: 100},
+		{limit: 350, wantBatch: 100},
+		{limit: 0, wantBatch: 1},
+		{limit: -1, wantBatch: 1},
+	} {
+		var gotBatch int
+		api := newFuncAPI(t, func(req bin.Encoder) (bin.Encoder, error) {
+			r, ok := req.(*tg.MessagesGetDialogsRequest)
+			if !ok {
+				return nil, errors.Errorf("unexpected request %T", req)
+			}
+			gotBatch = r.Limit
+			return &tg.MessagesDialogs{
+				Dialogs:  []tg.DialogClass{&tg.Dialog{Peer: &tg.PeerUser{UserID: 1}, TopMessage: 1}},
+				Messages: []tg.MessageClass{&tg.Message{ID: 1, PeerID: &tg.PeerUser{UserID: 1}, Date: 1}},
+				Users:    []tg.UserClass{&tg.User{ID: 1}},
+			}, nil
+		})
+
+		if _, err := listChats(context.Background(), api, nil, tt.limit, false); err != nil {
+			t.Fatalf("limit %d: %v", tt.limit, err)
+		}
+		if gotBatch != tt.wantBatch {
+			t.Errorf("limit %d: request limit = %d, want %d", tt.limit, gotBatch, tt.wantBatch)
+		}
+	}
+}

--- a/cmd/tg/drafts.go
+++ b/cmd/tg/drafts.go
@@ -47,7 +47,11 @@ func saveDraft(ctx context.Context, api *tg.Client, peer tg.InputPeerClass, text
 
 // listDrafts collects drafts from the dialog list.
 func listDrafts(ctx context.Context, api *tg.Client) (draftsResult, error) {
-	iter := query.GetDialogs(api).Iter()
+	// Scan every dialog to collect drafts. The iterator's default batch size is
+	// 1 (one messages.getDialogs RPC per dialog), so without batching this walks
+	// the whole account one round trip at a time. 100 is the per-request maximum
+	// Telegram serves.
+	iter := query.GetDialogs(api).BatchSize(100).Iter()
 	var out draftsResult
 	for iter.Next(ctx) {
 		elem := iter.Value()

--- a/cmd/tg/drafts_test.go
+++ b/cmd/tg/drafts_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/tg"
+)
+
+// TestListDraftsBatchSize asserts the dialog scan is batched at 100 per request
+// instead of the iterator default of 1: listDrafts walks every dialog, so a
+// batch size of 1 would issue one messages.getDialogs RPC per dialog.
+func TestListDraftsBatchSize(t *testing.T) {
+	var gotBatch int
+	api := newFuncAPI(t, func(req bin.Encoder) (bin.Encoder, error) {
+		r, ok := req.(*tg.MessagesGetDialogsRequest)
+		if !ok {
+			return nil, errors.Errorf("unexpected request %T", req)
+		}
+		gotBatch = r.Limit
+		return &tg.MessagesDialogs{
+			Dialogs: []tg.DialogClass{&tg.Dialog{
+				Peer:       &tg.PeerUser{UserID: 1},
+				TopMessage: 1,
+				Draft:      &tg.DraftMessage{Message: "wip"},
+			}},
+			Messages: []tg.MessageClass{&tg.Message{ID: 1, PeerID: &tg.PeerUser{UserID: 1}, Date: 1}},
+			Users:    []tg.UserClass{&tg.User{ID: 1}},
+		}, nil
+	})
+
+	res, err := listDrafts(context.Background(), api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBatch != 100 {
+		t.Errorf("request limit = %d, want 100", gotBatch)
+	}
+	if len(res.Drafts) != 1 || res.Drafts[0].Message != "wip" {
+		t.Errorf("drafts = %+v", res.Drafts)
+	}
+}


### PR DESCRIPTION
## Problem

`tg chats list` and `tg drafts` are slow for the same reason as #249, in a different command: the gotd dialogs iterator is created without a batch size, leaving the builder's **default of 1**. It therefore issues one `messages.getDialogs` RPC *per dialog*.

- `tg chats list` — one round trip per chat, up to `--limit` (default 100).
- `tg drafts` — worse: `listDrafts` scans **every dialog in the account** with no limit to find the ones with a draft, so it walks the whole list one round trip at a time.

## Fix

Set `BatchSize` on the builder:

- **chats** — `max(1, min(limit, 100))`, respecting `--limit`.
- **drafts** — flat `100` (full scan, no user-facing limit).

**Cap at 100** — Telegram does not reject a per-request limit above 100 but silently returns fewer/incorrect results (see gotd's own `BatchSize` doc; verified empirically against `messages.getHistory` — requesting 150/200 returns exactly 100), so 100 is the safe maximum. **Clamp to ≥ 1** (chats) — a non-positive batch size panics the iterator (`NewIterator` preallocates a slice with that capacity), so a negative `--limit` would otherwise crash the process.

## Tests

- `TestListChatsBatchSize` — asserts the per-request limit sent is `5/100/100` for `--limit 5/100/350` and clamps to `1` for `0/-1` (no panic).
- `TestListDraftsBatchSize` — asserts the dialog scan requests 100 per RPC.

Companion to #249 (same class of bug; `GetHistory` there, `GetDialogs` here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)